### PR TITLE
Add links to chapter "Finding more information" (8.7)

### DIFF
--- a/Documentation/FindingMoreInformation/Index.rst
+++ b/Documentation/FindingMoreInformation/Index.rst
@@ -12,90 +12,112 @@ Source Code
 The most authoritative and most current reference for TYPO3 Fluid information
 is, of course, the TYPO3 CMS source code itself.
 
-Here are some source code folders and files you may find useful. Substitute
-your own installed folder for :file:`typo3_src-8.7.13`.
+Here are some source code folders and files you may find useful.
 
-:file:`typo3_src-8.7.13/vendor/typo3fluid/fluid/doc`
+:file:`vendor/typo3fluid/fluid/doc`
 
-:file:`typo3_src-8.7.13/typo3/sysext/fluid_styled_content/Documentation/Introduction/Index.rst`
+:file:`typo3/sysext/fluid_styled_content/Documentation/Introduction/Index.rst`
 
-:file:`typo3_src-8.7.13/typo3/sysext/fluid`
+:file:`typo3/sysext/fluid`
 
 TYPO3 CMS source code also includes Fluid examples you may find useful.
 
-:file:`typo3_src-8.7.13/typo3/sysext/fluid_styled_content/Resources/Private`
+:file:`typo3/sysext/fluid_styled_content/Resources/Private`
 
-:file:`typo3_src-8.7.13/typo3/sysext/fluid/Resources/Private`
+:file:`typo3/sysext/fluid/Resources/Private`
 
-:file:`typo3_src-8.7.13/typo3/sysext/about/Resources/Private`
+:file:`typo3/sysext/about/Resources/Private`
 
 The [ https://api.typo3.org/ ] website provides an applications programming
 interface (API) viewer that can help you navigate parts of the TYPO3 CMS
 source code. Once you choose the TYPO3 CMS version, here are some navigation
 paths that may be useful.
 
-Classes > TYPO3 > CMS > Fluid
+`Classes > TYPO3 > CMS > Fluid`
 
-Classes > TYPO3 > CMS > FluidStyledContent
+`Classes > TYPO3 > CMS > FluidStyledContent`
 
-Classes > TYPO3 > CMS > Frontend > ContentObject > FluidTemplateContentObject
+`Classes > TYPO3 > CMS > Frontend > ContentObject > FluidTemplateContentObject`
 
-Published Documents
-===================
+Official Documentation
+======================
 
-There is a centralized documentation library at typo3.org containing links to
-tutorials, guides, reference manuals, code snippets, and videos. Some
-potentially useful documents are:
+There is a centralized documentation library at https://docs.typo3.org containing links to
+tutorials, guides, reference manuals and code snippets.
 
-*Developing TYPO3 Extensions with Extbase and Fluid*
 
-*A TYPO3 Extbase and Fluid Guide*
+These are the potentially useful manuals we will be referring to:
 
-*TypoScript in 45 Minutes*
+* :ref:`t3ts45:start`: This is an introductory tutorial to TypoScript Templating
+* :ref:`t3coreapi:typoscript-syntax-start` in the manual "TYPO3 Explained" walks you through
+  everything you need to know about the TypoScript syntax
+* :ref:`t3tsref:start`
+* :ref:`t3extbasebook:start` This is a resource for developing extensions using
+  Extbase and Fluid. The part about Extbase will not be relevant for you when
+  creating a site template, but you might find useful information in the Fluid
+  section :ref:`fluid-start`. Do note that this manual has a different scope,
+  as the Fluid here is used for generating output for Plugins.
 
-*TypoScript Reference* (“Content Objects” chapter, “FLUIDTEMPLATE” section)
+Fluid
+
+* https://typo3buddy.com/typo3-template-tutorial/fluid/
+* :ref:`t3vhref:typo3-fluid-cobject` (ViewHelper Reference)
+* :ref:`t3extbasebook:moving-repeating-snippets-to-partials` ("Developing TYPO3 Extensions with Extbase and Fluid")
+* :ref:`t3extbasebook:creating-a-consistent-look-and-feel-with-layouts` ("Developing TYPO3 Extensions with Extbase and Fluid")
+* `TYPO3/Fluid: doc <https://github.com/TYPO3/Fluid/tree/master/doc>`__, especially the :file:`FLUID_STRUCTURE.md` text file.
+
+
+TypoScript Templating
+
+* :ref:`t3coreapi:typoscript-syntax-start` (TYPO3 Explained)
+* :ref:`TypoScript syntax: conditions <t3coreapi:typoscript-syntax-conditions>` (TYPO3 Explained)
+* :ref:`t3tsref:cobj-fluidtemplate` (TypoScript Reference)
+* :ref:`t3tsref:cobj-hmenu` (TypoScript Reference)
+* :ref:`t3tsref:hmenu-special-rootline` (TypoScript Reference)
+* function: :ref:`t3ts45:function-if` (TypoScript in 45 Minutes), see also :ref:`t3tsref:if` in "TypoScript Reference"
+* :ref:`t3tsref:page` (TypoScript Reference)
+
+
+Videos
+======
+
+TYPO3 has an `official YouTube channel <https://www.youtube.com/channel/UCwpl8LY9Tr3PB26Kk2FYW_w>`__.
+
+You can find helpful videos about TYPO3 there, but not very much about templating on a beginner
+level.
+
+A video that may be useful:
+
+2017-11-10 **Tutorial - Site Packages - Part 1** by Mathias Schreiber
+
+.. youtube:: HtBmim7pc0o
+
 
 Searches
 ========
 
-Other than the typo3.org references, you can find additional information by
+Other than the docs.typo3.org references, you can find additional information by
 searching the Web. For example, try a search phrase such as
 [ :aspect:`typo3 fluid` ] on a popular video website. If you have a specific
 problem, think of key words or concepts to use in a search phrase. While
 writing this tutorial, Web searches led to these specific references.
 
-[ http://typo3buddy.com/ ] “Templates > Fluid templating”.
-
-[ https://docs.typo3.org/typo3cms/ExtbaseGuide/Fluid/ViewHelper/CObject.html ]
-
-[ https://docs.typo3.org/typo3cms/ExtbaseFluidBook/8-Fluid/3-moving-repeating-snippets-to-partials.html ]
-
-[ https://docs.typo3.org/typo3cms/ExtbaseFluidBook/8-Fluid/4-creating-a-consistent-look-and-feel-with-layouts.html ]
-
-[ :file:`typo3_src-8.7.13/vendor/typo3fluid/fluid/doc` ], especially the :file:`FLUID_STRUCTURE.md` text file.
-
-[ https://docs.typo3.org/typo3cms/TyposcriptReference/8.7/ContentObjects/Hmenu/Index.html ]
-
-[ https://docs.typo3.org/typo3cms/TyposcriptReference/8.7/ContentObjects/Hmenu/Index.html#special-rootline ]
-
-[ https://docs.typo3.org/typo3cms/TyposcriptReference/8.7/Functions/If/# ]
-
-[ https://docs.typo3.org/typo3cms/TyposcriptIn45MinutesTutorial/TypoScriptFunctions/If/Index.html ]
-
-[ https://docs.typo3.org/typo3cms/TyposcriptReference/8.7/Setup/Page/Index.html ]
-
-[ https://docs.typo3.org/typo3cms/TyposcriptReference/8.7/Conditions/Syntax/Index.html#general-syntax ]
-
-[ https://docs.typo3.org/typo3cms/TyposcriptReference/8.7/Conditions/Reference/Index.html#page ]
-
 Questions
 =========
 
 Lastly, after searching to find information already published, you may want
-to ask a question to the community. By now in your search, you will have
-gathered a list of useful websites and forums. Notice which forums have
-currently active participation, and take some time to familiarize yourself
-with their behavior and expectations.
+to ask the TYPO3 community.
+
+You can get information about where to get help on https://typo3.org/help.
+
+Specifically, choose one of these options:
+
+#. Ask **programming related questions** on
+   `Stack Overflow <https://stackoverflow.com/search?q=typo3>`__ using the tag "typo3"
+#. Ask general TYPO3 questions in the Slack channel #typo3-cms in the
+   `TYPO3 Slack workspace <https://typo3.slack.com>`__.
+   :ref:`Get your Slack invitation <https://my.typo3.org/about-mytypo3org/slack>`__ first.
+   
 
 Credit
 ======

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -29,5 +29,12 @@ use_opensearch       =
 
 ; in this manual we actually use:
 
-# t3tsref      = https://docs.typo3.org/typo3cms/TyposcriptReference
+t3coreapi      = https://docs.typo3.org/m/typo3/reference-coreapi/8.7/en-us/
+t3editors      = https://docs.typo3.org/m/typo3/tutorial-editors/8.7/en-us/
+t3extbasebook  = https://docs.typo3.org/m/typo3/book-extbasefluid/8.7/en-us/
+t3install      = https://docs.typo3.org/m/typo3/guide-installation/8.7/en-us/
+t3start        = https://docs.typo3.org/m/typo3/tutorial-getting-started/8.7/en-us/
+t3ts45         = https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/8.7/en-us/
+t3tsref        = https://docs.typo3.org/m/typo3/reference-typoscript/8.7/en-us/
+t3vhref        = https://docs.typo3.org/other/typo3/view-helper-reference/8.7/en-us
 


### PR DESCRIPTION
backport of #30

* Update and extend intersphinx mapping in Settings.cfg
* Use more links on the page "Finding information", linking
  to official documentation with :ref: instead of using
  absolute URLs
* Add video and information about official YouTube channel
* structure links to official documentation, categorizing by
  Fluid and TypoScript
* Add link to TypoScript syntax introduction in "TYPO3 Explained"
* Update section about asking questions to refer to Stack Overflow
  and Slack. Add link to official central help page https://typo3.org/help

Releases: master, 9.5, 8.7