### PR TITLE
[TASK] Mark TYPO3 Wiki as retired

### DIFF
--- a/Documentation/FindingMoreInformation/Index.rst
+++ b/Documentation/FindingMoreInformation/Index.rst
@@ -122,7 +122,7 @@ Specifically, choose one of these options:
 Credit
 ======
 
-The retired TYPO3 wiki was fundamental to starting the work leading to this tutorial.
+The retired TYPO3 Wiki was fundamental to starting the work leading to this tutorial.
 
 The following Web search results contributed directly to the tutorial’s final
 template design.


### PR DESCRIPTION
See https://github.com/TYPO3-Documentation/T3DocTeam/issues/170 for details.

Releases: main, 11.5, 10.4, 9.5, 8.7